### PR TITLE
Circumvent "port is already open"

### DIFF
--- a/transmission/transport_serial.py
+++ b/transmission/transport_serial.py
@@ -106,7 +106,8 @@ class SerialTransport(common.Transport):
                 xonxoff=0, # disable software flow control
                 rtscts=0, # disable RTS/CTS flow control
                 )
-        ser.open()
+	if ser.isOpen() == False:
+	        ser.open()
         # 8< got that from somwhere, not sure what it does:
         ser.setRTS(1)
         ser.setDTR(1)


### PR DESCRIPTION
Running the test_pt.py-script, there was an error, that the serialport was already open.

This seems to be caused by the fact, that the function in transport_serial.py is called multiple times - even when the port is already open.

This somewhat fixes the problem.
